### PR TITLE
clean up deprecation warnings

### DIFF
--- a/resources/log_file.rb
+++ b/resources/log_file.rb
@@ -26,24 +26,23 @@ end
 
 action :create do
   stream_name = sanitize(new_resource.name)
-  log_group_name = log_group_name.nil? ? new_resource.name : log_group_name
 
   template "#{node['cwlogs']['base_dir']}/etc/config/#{stream_name}.conf" do
     source 'log_file.conf.erb'
     cookbook 'cwlogs'
     variables(
-      log_group_name: log_group_name,
-      log_stream_name: log_stream_name,
-      datetime_format: datetime_format,
-      time_zone: time_zone,
-      file: file,
-      file_fingerprint_lines: file_fingerprint_lines,
-      multi_line_start_pattern: multi_line_start_pattern,
-      initial_position: initial_position,
-      encoding: encoding,
-      buffer_duration: buffer_duration,
-      batch_count: batch_count,
-      batch_size: batch_size
+      log_group_name: new_resource.log_group_name || new_resource.name,
+      log_stream_name: new_resource.log_stream_name,
+      datetime_format: new_resource.datetime_format,
+      time_zone: new_resource.time_zone,
+      file: new_resource.file,
+      file_fingerprint_lines: new_resource.file_fingerprint_lines,
+      multi_line_start_pattern: new_resource.multi_line_start_pattern,
+      initial_position: new_resource.initial_position,
+      encoding: new_resource.encoding,
+      buffer_duration: new_resource.buffer_duration,
+      batch_count: new_resource.batch_count,
+      batch_size: new_resource.batch_size
     )
     owner owner
     group group


### PR DESCRIPTION
This cleans up the following deprecation warnings

```Deprecated features used!
  rename log_stream_name to new_resource.log_stream_name at 1 location:
    - /var/chef/cache/cookbooks/cwlogs/resources/log_file.rb:36:in `block (2 levels) in class_from_file'
   See https://docs.chef.io/deprecations_namespace_collisions.html for further details.
  rename datetime_format to new_resource.datetime_format at 1 location:
    - /var/chef/cache/cookbooks/cwlogs/resources/log_file.rb:37:in `block (2 levels) in class_from_file'
   See https://docs.chef.io/deprecations_namespace_collisions.html for further details.
  rename time_zone to new_resource.time_zone at 1 location:
    - /var/chef/cache/cookbooks/cwlogs/resources/log_file.rb:38:in `block (2 levels) in class_from_file'
   See https://docs.chef.io/deprecations_namespace_collisions.html for further details.
  rename file to new_resource.file at 1 location:
    - /var/chef/cache/cookbooks/cwlogs/resources/log_file.rb:39:in `block (2 levels) in class_from_file'
   See https://docs.chef.io/deprecations_namespace_collisions.html for further details.
  rename file_fingerprint_lines to new_resource.file_fingerprint_lines at 1 location:
    - /var/chef/cache/cookbooks/cwlogs/resources/log_file.rb:40:in `block (2 levels) in class_from_file'
   See https://docs.chef.io/deprecations_namespace_collisions.html for further details.
  rename multi_line_start_pattern to new_resource.multi_line_start_pattern at 1 location:
    - /var/chef/cache/cookbooks/cwlogs/resources/log_file.rb:41:in `block (2 levels) in class_from_file'
   See https://docs.chef.io/deprecations_namespace_collisions.html for further details.
  rename initial_position to new_resource.initial_position at 1 location:
    - /var/chef/cache/cookbooks/cwlogs/resources/log_file.rb:42:in `block (2 levels) in class_from_file'
   See https://docs.chef.io/deprecations_namespace_collisions.html for further details.
  rename encoding to new_resource.encoding at 1 location:
    - /var/chef/cache/cookbooks/cwlogs/resources/log_file.rb:43:in `block (2 levels) in class_from_file'
   See https://docs.chef.io/deprecations_namespace_collisions.html for further details.
  rename buffer_duration to new_resource.buffer_duration at 1 location:
    - /var/chef/cache/cookbooks/cwlogs/resources/log_file.rb:44:in `block (2 levels) in class_from_file'
   See https://docs.chef.io/deprecations_namespace_collisions.html for further details.
  rename batch_count to new_resource.batch_count at 1 location:
    - /var/chef/cache/cookbooks/cwlogs/resources/log_file.rb:45:in `block (2 levels) in class_from_file'
   See https://docs.chef.io/deprecations_namespace_collisions.html for further details.
  rename batch_size to new_resource.batch_size at 1 location:
    - /var/chef/cache/cookbooks/cwlogs/resources/log_file.rb:46:in `block (2 levels) in class_from_file'
   See https://docs.chef.io/deprecations_namespace_collisions.html for further details.```