### PR TITLE
Fix logrotation in Ubuntu 12 and earlier

### DIFF
--- a/files/default/logrotate_awslogs
+++ b/files/default/logrotate_awslogs
@@ -1,0 +1,15 @@
+# DO NOT EDIT! This file is maintained by Chef
+# ALL EDITS WILL BE LOST WHEN CHEF RUNS
+
+/var/log/awslogs.log {
+    missingok
+    notifempty
+    size 100M
+    create 0600 root root
+    delaycompress
+    compress
+    rotate 4
+    postrotate
+        service awslogs restart
+    endscript
+}


### PR DESCRIPTION
`awslogs-agent-setup.py` assumes that all versions of Ubuntu support (and need) `su root root` in the logrotation file.  However Ubuntu 12.04 and earlier don't support the `su` directive, so this makes the daily cron installed by the logrotate package very noisey.