### PR TITLE
Delay attribute evaluation for aws credentials

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'mike.schuette@gmail.com'
 license          'FreeBSD'
 description      'Installs and configures AWS CloudWatch Logs'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.0.6'
+version          '0.0.7'
 source_url       'https://github.com/MikeSchuette/chef-cwlogs'
 issues_url       'https://github.com/MikeSchuette/chef-cwlogs/issues'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -52,6 +52,10 @@ template "#{node['cwlogs']['base_dir']}/etc/aws.conf" do
   owner 'root'
   group 'root'
   mode 0o644
+  variables(
+    aws_access_key_id: lazy { node['cwlogs']['aws_access_key_id'] },
+    aws_secret_access_key: lazy { node['cwlogs']['aws_secret_access_key'] }
+  )
 
   notifies :restart, 'service[awslogs]'
 end

--- a/templates/default/aws.conf.erb
+++ b/templates/default/aws.conf.erb
@@ -3,7 +3,7 @@ cwlogs = cwlogs
 
 [default]
 region = <%= node['cwlogs']['region'] %>
-<% if node['cwlogs']['aws_access_key_id'] && node['cwlogs']['aws_secret_access_key'] %>
-aws_access_key_id = <%= node['cwlogs']['aws_access_key_id'] %>
-aws_secret_access_key = <%= node['cwlogs']['aws_secret_access_key'] %>
+<% if @aws_access_key_id && @aws_secret_access_key %>
+aws_access_key_id = <%= @aws_access_key_id %>
+aws_secret_access_key = <%= @aws_secret_access_key %>
 <% end %>


### PR DESCRIPTION
Use aws credentials as lazy evaluated template variables.  This adds more options for pushing attribute assignment around in the runlist.